### PR TITLE
chore: remove commitlint configuration file

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,9 +1,0 @@
-export default {
-  extends: ['@commitlint/config-conventional'],
-  /*
-   * Any rules defined here will override rules from @commitlint/config-conventional
-   */
-  rules: {
-    'body-max-line-length': [2, 'always', 200],
-  },
-};


### PR DESCRIPTION
Delete the commitlint configuration file as it is no longer needed.  
This simplifies the project and reduces clutter, ensuring easier  
maintenance moving forward.