### PR TITLE
chore(terraform): update required_version to 1.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        tf-version: [ 1.1.9, 1.2.9, 1.3.2 ]
+        tf-version: [ 1.3.2 ]
     steps:
       - name: Start LocalStack
         uses: LocalStack/setup-localstack@9392b05ddb345894c2e86305fc426566e738c1db #v0.2.4

--- a/examples/basic/provider.tf
+++ b/examples/basic/provider.tf
@@ -41,5 +41,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }

--- a/examples/override/provider.tf
+++ b/examples/override/provider.tf
@@ -41,5 +41,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }

--- a/examples/public/provider.tf
+++ b/examples/public/provider.tf
@@ -41,5 +41,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -10,5 +10,5 @@ terraform {
       version = "~> 5.1"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Update the required Terraform version in multiple provider
configuration files from version 1.1.9 to 1.3 to ensure
compatibility with the latest features and improvements.