### PR TITLE
ci: drop LocalStack from examples build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,6 @@ jobs:
         os: [ ubuntu-latest ]
         tf-version: [ 1.3.2 ]
     steps:
-      - name: Start LocalStack
-        uses: LocalStack/setup-localstack@7c8a0cb3405bc58be4c8f763f812aa000bc46303 # v0.3.2
-        with:
-          image-tag: 'latest'
-
       - name: Install terraform v${{ matrix.tf-version }}
         run: |
           curl -LO https://releases.hashicorp.com/terraform/${{ matrix.tf-version }}/terraform_${{ matrix.tf-version }}_linux_amd64.zip

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,3 @@ example/%:
 	@echo "Processing example: $(notdir $*)"
 	@terraform -chdir=$* init
 	@terraform -chdir=$* validate
-	@terraform -chdir=$* plan

--- a/examples/basic/provider.tf
+++ b/examples/basic/provider.tf
@@ -1,37 +1,10 @@
 provider "aws" {
-  access_key                  = "test"
-  secret_key                  = "test"
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
   region                      = "us-east-1"
-  s3_use_path_style           = false
   skip_credentials_validation = true
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true
-
-  endpoints {
-    apigateway     = "http://localhost:4566"
-    apigatewayv2   = "http://localhost:4566"
-    cloudformation = "http://localhost:4566"
-    cloudwatch     = "http://localhost:4566"
-    dynamodb       = "http://localhost:4566"
-    ec2            = "http://localhost:4566"
-    es             = "http://localhost:4566"
-    elasticache    = "http://localhost:4566"
-    firehose       = "http://localhost:4566"
-    iam            = "http://localhost:4566"
-    kinesis        = "http://localhost:4566"
-    lambda         = "http://localhost:4566"
-    rds            = "http://localhost:4566"
-    redshift       = "http://localhost:4566"
-    route53        = "http://localhost:4566"
-    s3             = "http://s3.localhost.localstack.cloud:4566"
-    secretsmanager = "http://localhost:4566"
-    ses            = "http://localhost:4566"
-    sns            = "http://localhost:4566"
-    sqs            = "http://localhost:4566"
-    ssm            = "http://localhost:4566"
-    stepfunctions  = "http://localhost:4566"
-    sts            = "http://localhost:4566"
-  }
 }
 
 terraform {

--- a/examples/override/provider.tf
+++ b/examples/override/provider.tf
@@ -1,37 +1,10 @@
 provider "aws" {
-  access_key                  = "test"
-  secret_key                  = "test"
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
   region                      = "us-east-1"
-  s3_use_path_style           = false
   skip_credentials_validation = true
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true
-
-  endpoints {
-    apigateway     = "http://localhost:4566"
-    apigatewayv2   = "http://localhost:4566"
-    cloudformation = "http://localhost:4566"
-    cloudwatch     = "http://localhost:4566"
-    dynamodb       = "http://localhost:4566"
-    ec2            = "http://localhost:4566"
-    es             = "http://localhost:4566"
-    elasticache    = "http://localhost:4566"
-    firehose       = "http://localhost:4566"
-    iam            = "http://localhost:4566"
-    kinesis        = "http://localhost:4566"
-    lambda         = "http://localhost:4566"
-    rds            = "http://localhost:4566"
-    redshift       = "http://localhost:4566"
-    route53        = "http://localhost:4566"
-    s3             = "http://s3.localhost.localstack.cloud:4566"
-    secretsmanager = "http://localhost:4566"
-    ses            = "http://localhost:4566"
-    sns            = "http://localhost:4566"
-    sqs            = "http://localhost:4566"
-    ssm            = "http://localhost:4566"
-    stepfunctions  = "http://localhost:4566"
-    sts            = "http://localhost:4566"
-  }
 }
 
 terraform {

--- a/examples/public/provider.tf
+++ b/examples/public/provider.tf
@@ -1,37 +1,10 @@
 provider "aws" {
-  access_key                  = "test"
-  secret_key                  = "test"
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
   region                      = "us-east-1"
-  s3_use_path_style           = false
   skip_credentials_validation = true
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true
-
-  endpoints {
-    apigateway     = "http://localhost:4566"
-    apigatewayv2   = "http://localhost:4566"
-    cloudformation = "http://localhost:4566"
-    cloudwatch     = "http://localhost:4566"
-    dynamodb       = "http://localhost:4566"
-    ec2            = "http://localhost:4566"
-    es             = "http://localhost:4566"
-    elasticache    = "http://localhost:4566"
-    firehose       = "http://localhost:4566"
-    iam            = "http://localhost:4566"
-    kinesis        = "http://localhost:4566"
-    lambda         = "http://localhost:4566"
-    rds            = "http://localhost:4566"
-    redshift       = "http://localhost:4566"
-    route53        = "http://localhost:4566"
-    s3             = "http://s3.localhost.localstack.cloud:4566"
-    secretsmanager = "http://localhost:4566"
-    ses            = "http://localhost:4566"
-    sns            = "http://localhost:4566"
-    sqs            = "http://localhost:4566"
-    ssm            = "http://localhost:4566"
-    stepfunctions  = "http://localhost:4566"
-    sts            = "http://localhost:4566"
-  }
 }
 
 terraform {


### PR DESCRIPTION
## Summary
- Remove LocalStack step from `build.yml`; license activation now blocks `latest` image.
- Drop endpoints block + Makefile `terraform plan` so init+validate works without AWS.
- Aligns with the pattern already used in other Opzkit modules (e.g. external-dns).

## Test plan
- [x] `make examples` succeeds locally with all three examples (basic, override, public).
- [ ] CI examples job passes after merge.